### PR TITLE
resolving bug preventing the ability to ssh to packer vm

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -27,8 +27,8 @@ sed  -i "s/002/022/g" /etc/profile
 umask 022
 #disable root login
 systemctl stop sshd
-echo "PermitRootLogin no" >> /etc/ssh/ssh_config
-echo "PermitEmptyPasswords no" >> /etc/ssh/ssh_config
+echo "PermitRootLogin no" >> /etc/ssh/sshd_config
+echo "PermitEmptyPasswords no" >> /etc/ssh/sshd_config
 systemctl start sshd
 
 


### PR DESCRIPTION
When trying to ssh we get the following error:
[ywilliams@ip-10-235-8-197 ~]$ ssh 10.235.8.47
/etc/ssh/ssh_config: line 69: Bad configuration option: permitrootlogin
/etc/ssh/ssh_config: line 70: Bad configuration option: permitemptypasswords

The issue stems from the 2 lines below:

echo "PermitRootLogin no" >> /etc/ssh/ssh_config
echo "PermitEmptyPasswords no" >> /etc/ssh/ssh_config

Where these config changes are for the ssh daemon (so sshd_config not ssh_config)

To resolve I've also changed the commands from appending to the files and instead doing a find and replace. This is potentially safer command to run as this would not have caused the ssh_config file to break on top of the fact there are some config in the sshd_config that can only be at the end of a file where any new lines added to the end of the file may not work. e.g. Match block is one example although may be fixed with Match All at the end - https://unix.stackexchange.com/questions/67334/openssh-how-to-end-a-match-block

Please see https://github.com/ministryofjustice/modernisation-platform-environments/pull/100 where this feature branch has been used to re-create the bastion server and have tested the ability to ssh forward from the bastion to the packer vm.

Thanks to George for debugging this with me!