### PR TITLE
Reference the bucket name instead of generating it

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ data "template_file" "user_data" {
 
   vars = {
     aws_region              = var.region
-    bucket_name             = "${var.tags_prefix}-${var.bucket_name}"
+    bucket_name             = module.s3-bucket.bucket.id
     extra_user_data_content = var.extra_user_data_content
     allow_ssh_commands      = var.allow_ssh_commands
   }


### PR DESCRIPTION
Relevant post in slack from Ynyr:

Hi All, We are experiencing issues ssh’ing to our bastion on nomis as our public key is no longer trusted. This has started since our last deployment to the environment.
We believe we’ve traced the issue down to the last update to the bastion linux terraform module from 1.01 to 1.02. Specifically we think its the bucket name here. If someone could look into this for us and resolve?
```
ynyrwilliams@macbook-pro prod % ssh i-017683ef589db6a10
ywilliams@i-017683ef589db6a10: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).
ynyrwilliams@macbook-pro prod % ssh i-0c3f43c04ead258ad
```
