### PR TITLE
Output security group instead of private IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ locals {
 }
 
 module "bastion_linux" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v2.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-bastion-linux?ref=v2.0.2"
 
   providers = {
     aws.share-host   = aws.core-vpc            # core-vpc-(environment) holds the networking for all accounts

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ module "bastion_linux" {
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bastion_private_ip"></a> [bastion\_private\_ip](#output\_bastion\_private\_ip) | Private IP of bastion |
+| <a name="output_bastion_security_group"></a> [bastion\_security\_group](#output\_bastion\_security\_group) | Security group of bastion |
 
 <!--- END_TF_DOCS --->
 

--- a/main.tf
+++ b/main.tf
@@ -451,7 +451,7 @@ resource "aws_autoscaling_group" "bastion_linux_daily" {
 
   tag {
     key                 = "Name"
-    value               = "bastion_linux_autoscaling_group"
+    value               = "bastion_linux"
     propagate_at_launch = true
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 data "aws_instances" "ecs_instances_meta" {
+  depends_on = [ "aws_autoscaling_group.bastion_linux_daily" ]
   instance_tags = {
     Name = "bastion_linux"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,4 @@
-data "aws_instances" "ecs_instances_meta" {
-  depends_on    = [aws_autoscaling_group.bastion_linux_daily]
-  instance_tags = {
-    Name = "bastion_linux"
-  }
-}
-
-output "bastion_private_ip" {
-  description = "Private IP of bastion"
-  value       = data.aws_instances.ecs_instances_meta.private_ips[0]
+output "bastion_security_group" {
+  description = "Security group of bastion"
+  value       = aws_security_group.bastion_linux.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 data "aws_instances" "ecs_instances_meta" {
-  depends_on = [ "aws_autoscaling_group.bastion_linux_daily" ]
+  depends_on    = [aws_autoscaling_group.bastion_linux_daily]
   instance_tags = {
     Name = "bastion_linux"
   }

--- a/user_data.sh
+++ b/user_data.sh
@@ -175,3 +175,10 @@ rm ~/mycron
 #######################################
 
 ${extra_user_data_content}
+
+##########################################################
+## Add bastion version info to /etc/bastion_version.txt ##
+##########################################################
+cat > /etc/bastion_version.txt << 'EOF'
+bastion_version="2.0.2"
+EOF


### PR DESCRIPTION
- Update documentation
- Output `bastion_security_group` instead of `bastion_private_ip`. As the IP will change on daily basis upon termination, it is preferred to use the security group at the consumer's end. 
- Add bastion version info to `/etc/bastion_version.txt`

Following is an example configuration where we use `bastion_security_group` instead of `bastion_private_ip`.

```
resource "aws_security_group" "db_mgmt_server_security_group" {
...
  ingress {
    ...
    cidr_blocks = ["${module.bastion_linux.bastion_private_ip}/32"]
  }
...
}
```

The above can be configured as follows with the `bastion_security_group`:

```
resource "aws_security_group" "db_mgmt_server_security_group" {
...
  ingress {
    ...
    security_groups = [module.bastion_linux.bastion_security_group]
  }
...
}
```

The solution has been tested on sprinkler-development with the following scenarios:

```
Feature: Sprinkler test scenarios

  Background:
    Given aws profile sprinkler-development
    And region eu-west-2

  Scenario: bastion can access db-mgmt-server
    When i-0cd130d3bdacc00a5 connects to 10.234.0.154 on port 3389 with timeout 2 seconds
    Then connection is successful

  Scenario: db-mgmt-server can access bastion
    When i-0cd130d3bdacc00a5 connects to 10.234.0.248 on port 80 with timeout 2 seconds
    Then connection is successful
```