### PR TITLE
Clear bastion S3 bucket on deletion

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ module "s3-bucket" {
   }
   bucket_name         = "${var.bucket_name}-${var.tags_prefix}-${lower(random_string.random6.result)}"
   replication_enabled = false
+  force_destroy = true
 
   lifecycle_rule = [
     {

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "s3-bucket" {
   }
   bucket_name         = "${var.bucket_name}-${var.tags_prefix}-${lower(random_string.random6.result)}"
   replication_enabled = false
-  force_destroy = true
+  force_destroy       = true
 
   lifecycle_rule = [
     {


### PR DESCRIPTION
* set `var.force_destroy = true` so that S3 bucket is purged on deletion

This bucket exists to hold the public SSH keys of authorised bastion users, so clearing it on deletion is appropriate.