### PR TITLE
Adding template provider back for a graceful faze out

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ In order to prevent older versions from being retained forever, in addition to t
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.4 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.2 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -9,6 +9,11 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.4"
     }
+    // Keeping this provider until it gets fazed out in member accounts
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2"
+    }
   }
   required_version = ">= 1.0.1"
 }


### PR DESCRIPTION
The removal of the deprecated `hashicorp/template` provider breaks GH actions in member accounts, where the load balancer is already running. Therefore adding it back for the time being, until all of the running LoadBalancers get upgraded.