### PR TITLE
Generalising test code to work with and without workspaces.

### DIFF
--- a/test/bastion_test.go
+++ b/test/bastion_test.go
@@ -15,10 +15,11 @@ func TestBastionCreation(t *testing.T) {
 		TerraformDir: "./unit-test",
 	})
 
-    // Would fail if lifecycle.prevent_destroy is set on the bucket
+	// Would fail if lifecycle.prevent_destroy is set on the bucket
 	defer terraform.Destroy(t, terraformOptions)
 
 	terraform.InitAndApply(t, terraformOptions)
+	workspace := terraform.RunTerraformCommand(t, terraformOptions, "workspace", "show")
 
 	bastionSecurityGroup := terraform.Output(t, terraformOptions, "bastion_security_group")
 	bastionLaunchTemplate := terraform.Output(t, terraformOptions, "bastion_launch_template")
@@ -27,5 +28,5 @@ func TestBastionCreation(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`^sg-*`), bastionSecurityGroup)
 	assert.Contains(t, bastionLaunchTemplate, "arn:aws:ec2:eu-west-2:")
 	assert.Contains(t, bastionLaunchTemplate, "instance_type:t3.micro")
- 	assert.Contains(t, bastionS3Bucket, "arn:aws:s3:::bastion-testing-test-")
+	assert.Contains(t, bastionS3Bucket, "arn:aws:s3:::bastion-"+workspace+"-")
 }


### PR DESCRIPTION
The go-test is currently failing because there's a hardcoded reference to a workspace. As we might be reverting the change removing the backend, the test as written will test for bucket creation whether a workspace has been used or not.
