### PR TITLE
Removing template provider definition

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -9,11 +9,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.4"
     }
-    // Keeping this provider until it gets fazed out in member accounts
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.2"
-    }
   }
   required_version = ">= 1.0.1"
 }


### PR DESCRIPTION
`template_file` by hashicorp/template provider has been already replaced  with `templatefile` tf native function with the last release/tag. This change is to remove its definition, which was kept for a graceful faze out (if there were live bastions using the old code, tearing them down would cause an issue, as the state file would have references to the old template_file resource).

There should be no more bastions using the `template_file` therefore this provider can be now removed.