### PR TITLE
Pointed to latest s3-bucket release and stopped a KMS checkov - CKV2_A…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In order to prevent older versions from being retained forever, in addition to t
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 8688bc15a08fbf5a4f4eef9b7433c5a417df8df1 |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 568694e50e03630d99cb569eafa06a0b879a1239 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,8 @@ resource "random_string" "random6" {
 }
 
 module "s3-bucket" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.0.0"
+   #checkov:skip=CKV2_AWS_64: "Ensure KMS key Policy is defined - not needed here"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=v7.1.0"
 
   providers = {
     # Since replication_enabled is false, the below provider is not being used.

--- a/main.tf
+++ b/main.tf
@@ -102,7 +102,7 @@ resource "random_string" "random6" {
 }
 
 module "s3-bucket" {
-   #checkov:skip=CKV2_AWS_64: "Ensure KMS key Policy is defined - not needed here"
+  #checkov:skip=CKV2_AWS_64: "Ensure KMS key Policy is defined - not needed here"
   source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=568694e50e03630d99cb569eafa06a0b879a1239"
 
   providers = {


### PR DESCRIPTION
…WS_64 - check.

Wanted to check the KMS key.

Another checkov (CKV_TF_1) is showing as failing but may be cured by pointing to the latest version of the modernisation-platform-terraform-s3-bucket code. If not additional work is required.