### PR TITLE
Add user sync script call to userdata

### DIFF
--- a/templates/user_data.sh.tftpl
+++ b/templates/user_data.sh.tftpl
@@ -168,7 +168,10 @@ EOF
 crontab ~/mycron
 rm ~/mycron
 
-
+############################################
+## RUN USER SYNC IMMEDIATELY AFTER LAUNCH ##
+############################################
+/usr/bin/bastion/sync_users
 
 #########################################
 ## Add Custom extra_user_data_content ##


### PR DESCRIPTION
Call the user script script after setting up the cron so that there isn't a 15 minute wait on instance first launch