### PR TITLE
Updated template to use dynamic resolution of SSM parameter store value

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ In order to prevent older versions from being retained forever, in addition to t
 | [aws_security_group_rule.bastion_linux_egress_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.bastion_linux_egress_3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [random_string.random6](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [aws_ami.linux_2_image](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.bastion_assume_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.bastion_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/main.tf
+++ b/main.tf
@@ -379,22 +379,6 @@ resource "aws_iam_instance_profile" "bastion_profile" {
 }
 
 ## Bastion
-
-data "aws_ami" "linux_2_image" {
-  most_recent = true
-  owners      = ["amazon"]
-
-  filter {
-    name   = "name"
-    values = ["amzn2-ami-hvm*"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-}
-
 resource "aws_launch_template" "bastion_linux_template" {
   name = "${var.instance_name}_template"
 
@@ -413,7 +397,7 @@ resource "aws_launch_template" "bastion_linux_template" {
     name = aws_iam_instance_profile.bastion_profile.id
   }
 
-  image_id                             = data.aws_ami.linux_2_image.id
+  image_id                             = "resolve:ssm:/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"
   instance_initiated_shutdown_behavior = "terminate"
   instance_type                        = "t3.micro"
 


### PR DESCRIPTION
This PR resolves [#1385](https://github.com/ministryofjustice/modernisation-platform/issues/1385) in the Modernisation Platform repository.

This PR replaces the data call which can result in outdated AMI versions being used in templates, for a public SSM Parameter resolve statement which will return the `value` from the parameter when instances are created, ensuring that the latest version is used.