### PR TITLE
Add alias for MP S3 KMS key

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ In order to prevent older versions from being retained forever, in addition to t
 | [aws_iam_role_policy_attachment.bastion_host_ssm_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.bastion_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.bastion_s3_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,12 @@ resource "aws_kms_key" "bastion_s3" {
   )
 }
 
+resource "aws_kms_alias" "bastion_s3" {
+  count         = var.custom_s3_kms_arn != "" ? 0 : 1
+  name_prefix   = "alias/modernisation-platform-bastion"
+  target_key_id = aws_kms_key.bastion_s3[0].id
+}
+
 resource "aws_kms_alias" "bastion_s3_alias" {
   count = var.custom_s3_kms_arn != "" ? 0 : 1
 


### PR DESCRIPTION
Tracked upstream by #[7569](https://github.com/ministryofjustice/modernisation-platform/issues/7569).

This PR adds a `name_prefix`ed KMS alias to identify the KMS key used by the bastion module. A forthcoming PR will add unit tests.