### PR TITLE
Refactor unit tests

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - uses: ministryofjustice/github-actions/code-formatter@8712624bc5138cb320d9e5a2c5d87d9cb92f9900 # v18.2.2
+      - uses: ministryofjustice/github-actions/code-formatter@e08cbcac12ec9c09d867ab2b803d4ea1a87300ad # v18.2.4
         with:
             ignore-files: "README.md"
         env:

--- a/.github/workflows/terraform-static-analysis.yml
+++ b/.github/workflows/terraform-static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@8712624bc5138cb320d9e5a2c5d87d9cb92f9900 # v18.2.2
+        uses: ministryofjustice/github-actions/terraform-static-analysis@e08cbcac12ec9c09d867ab2b803d4ea1a87300ad # v18.2.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -52,7 +52,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Analysis
-        uses: ministryofjustice/github-actions/terraform-static-analysis@8712624bc5138cb320d9e5a2c5d87d9cb92f9900 # v18.2.2
+        uses: ministryofjustice/github-actions/terraform-static-analysis@e08cbcac12ec9c09d867ab2b803d4ea1a87300ad # v18.2.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,6 @@ In order to prevent older versions from being retained forever, in addition to t
 | [aws_iam_role_policy_attachment.bastion_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
-| [aws_kms_alias.bastion_s3_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.bastion_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_launch_template.bastion_linux_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
@@ -181,6 +180,8 @@ In order to prevent older versions from being retained forever, in addition to t
 | Name | Description |
 |------|-------------|
 | <a name="output_bastion_iam_role"></a> [bastion\_iam\_role](#output\_bastion\_iam\_role) | IAM role of bastion |
+| <a name="output_bastion_kms_key"></a> [bastion\_kms\_key](#output\_bastion\_kms\_key) | n/a |
+| <a name="output_bastion_kms_key_alias"></a> [bastion\_kms\_key\_alias](#output\_bastion\_kms\_key\_alias) | n/a |
 | <a name="output_bastion_launch_template"></a> [bastion\_launch\_template](#output\_bastion\_launch\_template) | Launch template of bastion |
 | <a name="output_bastion_s3_bucket"></a> [bastion\_s3\_bucket](#output\_bastion\_s3\_bucket) | S3 bucket of bastion |
 | <a name="output_bastion_security_group"></a> [bastion\_security\_group](#output\_bastion\_security\_group) | Security group of bastion |

--- a/main.tf
+++ b/main.tf
@@ -67,13 +67,6 @@ resource "aws_kms_alias" "bastion_s3" {
   target_key_id = aws_kms_key.bastion_s3[0].id
 }
 
-resource "aws_kms_alias" "bastion_s3_alias" {
-  count = var.custom_s3_kms_arn != "" ? 0 : 1
-
-  name          = "alias/s3-${var.bucket_name}_key"
-  target_key_id = aws_kms_key.bastion_s3[0].arn
-}
-
 resource "aws_kms_key_policy" "bastion_s3" {
   count = var.custom_s3_kms_arn != "" ? 0 : 1
 

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ data "aws_vpc_endpoint" "s3" {
 
 # S3
 resource "aws_kms_key" "bastion_s3" {
+  #checkov:skip=CKV2_AWS_64: Policy defined in separate resource
   count               = var.custom_s3_kms_arn != "" ? 0 : 1
   enable_key_rotation = true
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,8 +13,15 @@ output "bastion_s3_bucket" {
   value       = module.s3-bucket
 }
 
-
 output "bastion_iam_role" {
   description = "IAM role of bastion"
   value       = aws_iam_role.bastion_role
+}
+
+output "bastion_kms_key" {
+  value = aws_kms_key.bastion_s3
+}
+
+output "bastion_kms_key_alias" {
+  value = aws_kms_alias.bastion_s3
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "bastion_security_group" {
   description = "Security group of bastion"
-  value       = aws_security_group.bastion_linux.id
+  value       = aws_security_group.bastion_linux
 }
 
 output "bastion_launch_template" {

--- a/test/module_test.go
+++ b/test/module_test.go
@@ -20,21 +20,20 @@ func TestBastionCreation(t *testing.T) {
 
 	terraform.InitAndApply(t, terraformOptions)
 
-	bastionSecurityGroup1 := terraform.Output(t, terraformOptions, "bastion_security_group_1")
-	bastionLaunchTemplate1 := terraform.Output(t, terraformOptions, "bastion_launch_template_1")
-	bastionS3Bucket1 := terraform.Output(t, terraformOptions, "bastion_s3_bucket_1")
+	bastionKMS := terraform.OutputMap(t, terraformOptions, "bastion_kms_key")
+	bastionLaunchTemplate := terraform.OutputMap(t, terraformOptions, "bastion_launch_template")
+	bastionSecurityGroup := terraform.OutputMap(t, terraformOptions, "bastion_security_group")
+	bastionS3Bucket := terraform.OutputMap(t, terraformOptions, "bastion_s3_bucket")
 
-	assert.Regexp(t, regexp.MustCompile(`^sg-*`), bastionSecurityGroup1)
-	assert.Contains(t, bastionLaunchTemplate1, "arn:aws:ec2:eu-west-2:")
-	assert.Contains(t, bastionLaunchTemplate1, "instance_type:t3.micro")
-	assert.Contains(t, bastionS3Bucket1, "arn:aws:s3:::bastion-1-testing-test-")
+	assert.Regexp(t, regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), bastionKMS["bastion_0"])
+	assert.Regexp(t, regexp.MustCompile(`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`), bastionKMS["bastion_1"])
 
-	bastionSecurityGroup2 := terraform.Output(t, terraformOptions, "bastion_security_group_2")
-	bastionLaunchTemplate2 := terraform.Output(t, terraformOptions, "bastion_launch_template_2")
-	bastionS3Bucket2 := terraform.Output(t, terraformOptions, "bastion_s3_bucket_2")
+	assert.Regexp(t, regexp.MustCompile(`lt-[a-f0-9]{17}`), bastionLaunchTemplate["bastion_0"])
+	assert.Regexp(t, regexp.MustCompile(`lt-[a-f0-9]{17}`), bastionLaunchTemplate["bastion_1"])
 
-	assert.Regexp(t, regexp.MustCompile(`^sg-*`), bastionSecurityGroup2)
-	assert.Contains(t, bastionLaunchTemplate2, "arn:aws:ec2:eu-west-2:")
-	assert.Contains(t, bastionLaunchTemplate2, "instance_type:t3.micro")
-	assert.Contains(t, bastionS3Bucket2, "arn:aws:s3:::bastion-2-testing-test-")
+	assert.Regexp(t, regexp.MustCompile(`sg-[a-f0-9]{17}`), bastionSecurityGroup["bastion_0"])
+	assert.Regexp(t, regexp.MustCompile(`sg-[a-f0-9]{17}`), bastionSecurityGroup["bastion_1"])
+
+	assert.Regexp(t, regexp.MustCompile(`bastion-\d-testing-test-[a-z0-9]{6}`), bastionS3Bucket["bastion_0"])
+	assert.Regexp(t, regexp.MustCompile(`bastion-\d-testing-test-[a-z0-9]{6}`), bastionS3Bucket["bastion_1"])
 }

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -1,19 +1,19 @@
 output "bastion_launch_template" {
   description = "Bastion launch templates"
-  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_launch_template }
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_launch_template.id }
 }
 
 output "bastion_s3_bucket" {
   description = "Bastion S3 buckets"
-  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_s3_bucket }
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_s3_bucket.bucket.id }
 }
 
 output "bastion_security_group" {
   description = "Bastion security groups"
-  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_security_group }
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_security_group.id }
 }
 
 output "bastion_kms_key" {
   description = "Bastion KMS keys"
-  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_kms_key }
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_kms_key[0].id }
 }

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -1,33 +1,19 @@
-output "bastion_security_group_1" {
-  description = "Security group of bastion"
-  value       = module.bastion_linux[0].bastion_security_group
+output "bastion_launch_template" {
+  description = "Bastion launch templates"
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_launch_template }
 }
 
-output "bastion_launch_template_1" {
-  description = "Launch template of bastion"
-  value       = module.bastion_linux[0].bastion_launch_template
+output "bastion_s3_bucket" {
+  description = "Bastion S3 buckets"
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_s3_bucket }
 }
 
-output "bastion_s3_bucket_1" {
-  description = "S3 bucket of bastion"
-  value       = module.bastion_linux[0].bastion_s3_bucket
-}
-
-output "bastion_security_group_2" {
-  description = "Security group of bastion"
-  value       = module.bastion_linux[1].bastion_security_group
-}
-
-output "bastion_launch_template_2" {
-  description = "Launch template of bastion"
-  value       = module.bastion_linux[1].bastion_launch_template
-}
-
-output "bastion_s3_bucket_2" {
-  description = "S3 bucket of bastion"
-  value       = module.bastion_linux[1].bastion_s3_bucket
+output "bastion_security_group" {
+  description = "Bastion security groups"
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_security_group }
 }
 
 output "bastion_kms_key" {
-  value = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_kms_key }
+  description = "Bastion KMS keys"
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_kms_key }
 }

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -27,3 +27,7 @@ output "bastion_s3_bucket_2" {
   description = "S3 bucket of bastion"
   value       = module.bastion_linux[1].bastion_s3_bucket
 }
+
+output "bastion_kms_key" {
+  value = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_kms_key }
+}

--- a/test/unit-test/versions.tf
+++ b/test/unit-test/versions.tf
@@ -4,6 +4,10 @@ terraform {
       version = "~> 5.0"
       source  = "hashicorp/aws"
     }
+    http = {
+      version = "~> 3.0"
+      source  = "hashicorp/http"
+    }
   }
-  required_version = ">= 1.0.1"
+  required_version = "~> 1.0"
 }


### PR DESCRIPTION
This PR is tracked upstream by #[7569](https://github.com/ministryofjustice/modernisation-platform/issues/7569).

This PR does the following:
* Removes a duplicate alias resource that does not make use of `name_prefix` to ensure a unique alias.
* Creates additional outputs in the root of the module
* Refactors the outputs in the `unit-test` module to be more dynamic than the old hardcoded ones
* Updates the unit tests to query the new outputs

The unit tests are still a little declarative for my tastes, but they're functional.