### PR TITLE
Reinstated original behaviour of security group output

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ In order to prevent older versions from being retained forever, in addition to t
 | <a name="output_bastion_launch_template"></a> [bastion\_launch\_template](#output\_bastion\_launch\_template) | Launch template of bastion |
 | <a name="output_bastion_s3_bucket"></a> [bastion\_s3\_bucket](#output\_bastion\_s3\_bucket) | S3 bucket of bastion |
 | <a name="output_bastion_security_group"></a> [bastion\_security\_group](#output\_bastion\_security\_group) | Security group of bastion |
+| <a name="output_bastion_security_group_map"></a> [bastion\_security\_group\_map](#output\_bastion\_security\_group\_map) | Security group details of bastion |
 <!-- END_TF_DOCS -->
 
 [Standards Link]: https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/public-report/modernisation-platform-terraform-bastion-linux "Repo standards badge."

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,10 @@
 output "bastion_security_group" {
   description = "Security group of bastion"
+  value       = aws_security_group.bastion_linux.id
+}
+
+output "bastion_security_group_map" {
+  description = "Security group details of bastion"
   value       = aws_security_group.bastion_linux
 }
 

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -10,7 +10,7 @@ output "bastion_s3_bucket" {
 
 output "bastion_security_group" {
   description = "Bastion security groups"
-  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_security_group.id }
+  value       = { for idx, bastion in module.bastion_linux : "bastion_${idx}" => bastion.bastion_security_group_map.id }
 }
 
 output "bastion_kms_key" {


### PR DESCRIPTION
This PR reverts the change to the `bastion_security_group` output and places the changed functionality into a new output - `bastion_security_group_map`.

This will prevent customers experiencing breaking changes from upgrading to the latest module version.

When a future major version bump is announced we expect to remove the old output which will necessitate small adjustments by users.