### PR TITLE
Migrate `format-code` to use reusable workflow from modernisation-platform-github-actions

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -3,17 +3,26 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-permissions: {}
-
+permissions: read-all
+  
 jobs:
   format-code:
     permissions:
       contents: write
+      security-events: write  # needed for SARIF upload
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ministryofjustice/github-actions/code-formatter@db1a54895bf5fb975c60af47e5a3aab96505ca3e # v18.6.0
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run Format Code Action
+        uses: ministryofjustice/modernisation-platform-github-actions/format-code@2d1bb8ef39861ede2999271b530cb9dd87f18004 # v3.3.1
         with:
-            ignore-files: "README.md"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ignore_files: "README.md"
+
+      - name: Run Signed Commit Action
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@2d1bb8ef39861ede2999271b530cb9dd87f18004 # v3.3.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "GitHub Actions Code Formatter workflow"
+          pr_body: "This pull request includes updates from the GitHub Actions Code Formatter workflow. Please review the changes and merge if everything looks good."

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .DS_Store
 tmp/
+megalinter-reports
 
 ##########################
 ## IntelliJ


### PR DESCRIPTION
This PR adds the new [format-code](https://github.com/ministryofjustice/modernisation-platform-github-actions/tree/main/format-code) GitHub Action workflow to standardise code formatting across this repository.

- ✅ Introduces a reusable workflow to run MegaLinter and optionally apply automatic fixes.
- 🔐 Uses the latest pinned SHA versions of the `format-code` and `signed-commit` actions for security and reproducibility.
- ✍️ Automatically commits any formatting changes via a signed commit, where applicable.

This aligns the repo with the Modernisation Platform’s shared formatting and linting standards.