### PR TITLE
Fix S3 object tag limit

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -180,12 +180,6 @@ resource "aws_s3_object" "bucket_public_keys_readme" {
   kms_key_id = local.kms_key_arn
 
   tags = var.tags_common
-
-  override_provider {
-    default_tags {
-      tags = {}
-    }
-  }
 }
 
 resource "aws_s3_object" "user_public_keys" {
@@ -197,12 +191,6 @@ resource "aws_s3_object" "user_public_keys" {
   kms_key_id = local.kms_key_arn
 
   tags = var.tags_common
-
-  override_provider {
-    default_tags {
-      tags = {}
-    }
-  }
 }
 
 # Security Groups

--- a/main.tf
+++ b/main.tf
@@ -179,13 +179,13 @@ resource "aws_s3_object" "bucket_public_keys_readme" {
   content    = "Drop here the ssh public keys of the instances you want to control"
   kms_key_id = local.kms_key_arn
 
-  tags = merge(
-    var.tags_common,
-    {
-      Name = "bastion-${var.app_name}-README.txt"
-    }
-  )
+  tags = var.tags_common
 
+  override_provider {
+    default_tags {
+      tags = {}
+    }
+  }
 }
 
 resource "aws_s3_object" "user_public_keys" {
@@ -196,13 +196,13 @@ resource "aws_s3_object" "user_public_keys" {
   content    = each.value
   kms_key_id = local.kms_key_arn
 
-  tags = merge(
-    var.tags_common,
-    {
-      Name = "bastion-${var.app_name}-${each.key}-publickey"
-    }
-  )
+  tags = var.tags_common
 
+  override_provider {
+    default_tags {
+      tags = {}
+    }
+  }
 }
 
 # Security Groups


### PR DESCRIPTION
When var.tags_common already contains 10 tags, adding Name creates 11, so PutObject fails with:

BadRequest: Object tags cannot be greater than 10
So the fix is to keep object tags at 10 or fewer by removing the extra Name tag from aws_s3_object resources. The Name tag isn’t needed on these specific S3 objects because the object key already gives them a clear identity.