### PR TITLE
Update S3 Module to release 10.2.0 to enforce use of aws:SecureTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ In order to prevent older versions from being retained forever, in addition to t
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 9facf9fc8f8b8e3f93ffbda822028534b9a75399 |
+| <a name="module_s3-bucket"></a> [s3-bucket](#module\_s3-bucket) | github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket | 355197b5695fcce014ad838c7b586b95f9eb4988 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "random_string" "random6" {
 #tfsec:ignore:avd-aws-0132 - The bucket policy is attached to the bucket
 module "s3-bucket" {
   #checkov:skip=CKV2_AWS_64: "Ensure KMS key Policy is defined - not needed here"
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399" # v9.0.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=355197b5695fcce014ad838c7b586b95f9eb4988" # v10.2.0
 
   providers = {
     # Since replication_enabled is false, the below provider is not being used.
@@ -121,7 +121,7 @@ module "s3-bucket" {
   replication_enabled = false
   force_destroy       = true
 
-  custom_kms_key = var.custom_s3_kms_arn != "" ? var.custom_s3_kms_arn : ""
+  custom_kms_key = local.kms_key_arn
 
   lifecycle_rule = [
     {

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -27,6 +27,9 @@ module "bastion_linux" {
   # bastion
   allow_ssh_commands = false
 
+  # KMS - not setting custom_s3_kms_arn, so module will create its own KMS key with key rotation enabled
+  # custom_s3_kms_arn = "" # default - module creates KMS key, alias, and policy
+
   app_name      = var.networking[0].application
   business_unit = local.vpc_name
   subnet_set    = local.subnet_set


### PR DESCRIPTION
As per title, the version of the s3 module used by the bastion is 12 months out. This brings it up to date.

Bastion tested in cooker